### PR TITLE
fix: remove invalid autoMergeAllowed field from getRepoInfo

### DIFF
--- a/src/executor.js
+++ b/src/executor.js
@@ -843,7 +843,7 @@ export async function createPR(repo, { title, body, head, base, draft = false, l
 export async function getRepoInfo(repo) {
   const args = [
     'repo', 'view', getRepo(repo),
-    '--json', 'name,owner,defaultBranchRef,squashMergeAllowed,mergeCommitAllowed,rebaseMergeAllowed,autoMergeAllowed,deleteBranchOnMerge,viewerPermission',
+    '--json', 'name,owner,defaultBranchRef,squashMergeAllowed,mergeCommitAllowed,rebaseMergeAllowed,deleteBranchOnMerge,viewerPermission',
   ]
   return run(args)
 }


### PR DESCRIPTION
## Summary
- `gh repo view` does not support `autoMergeAllowed` as a JSON field in the installed gh version
- This caused `getRepoInfo` to throw an error on every call, keeping `repoInfo` permanently `null`
- With `repoInfo === null`, the `--admin` merge option never appeared in the merge dialog
- Fix: remove `autoMergeAllowed` from the `--json` field list; all other fields are valid

## Test plan
- [ ] Open a PR detail view and press `m` to open merge dialog
- [ ] Verify `--admin` option appears (for repo admins)
- [ ] All 90 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)