### PR TITLE
feat(nvim): Phase 1 — ambient PR status, smart :LazyHubPR, LazyExtras

### DIFF
--- a/NVIM_INTEGRATION_SPEC.md
+++ b/NVIM_INTEGRATION_SPEC.md
@@ -1,0 +1,341 @@
+# lazyhub.nvim — Deep Editor Integration Spec
+
+> **Status:** Proposed
+> **Owner:** integrations/nvim
+> **Related:** `src/ipc.js`, `integrations/nvim/`, `ARCHITECTURE.md`
+> **Audience:** Any contributor (human or AI) implementing the editor surface.
+
+---
+
+## 1. Vision
+
+> User edits code in nvim → stages with **lazygit** → manages GitHub collaboration with **lazyhub** — all keyboard-driven, all in one terminal session.
+>
+> **Three keys, three tools:**
+> - `<leader>gg` → lazygit (file changes, commits, branches)
+> - `<leader>gh` → lazyhub (PRs, issues, reviews, CI, notifications)
+> - `<leader>gr` → review overlay (inline PR comments in the current buffer)
+
+Goal: a LazyVim/AstroNvim user installs lazyhub, gets a native-feeling GitHub workflow, never opens a browser, never alt-tabs.
+
+### Non-goals
+
+- Replacing `octo.nvim`'s buffer-native PR rendering. We keep the float TUI as the primary GitHub surface; nvim is the *editor-side* glue.
+- Reimplementing GitHub features in Lua. All GitHub state lives in the lazyhub TUI; the plugin is a thin client over IPC + `gh`.
+- Authoring/editing issues from nvim (low frequency — the float is fine).
+
+---
+
+## 2. Current state (baseline)
+
+Already shipped in `integrations/nvim/`:
+
+| Command | Behavior |
+|---|---|
+| `:LazyHub` | Opens lazyhub in a floating terminal |
+| `:LazyHubPR` | Opens lazyhub, passes current branch via env |
+| `:LazyHubBlame` | `git blame` line → finds PR by commit SHA → opens lazyhub navigated to it |
+| `:LazyHubDiag` | Pulls PR review comments via `gh api`, sets them as `vim.diagnostic` entries |
+| `:LazyHubState` | Shows current lazyhub pane/view/PR from IPC |
+
+IPC server (`src/ipc.js`) supports:
+- Requests: `ping`, `state`, `navigate`, `open-file`
+- Events broadcast to all clients: `cursor-changed`, `view-changed`, `pr-merged`
+
+Discovery via `~/.lazyhub-socket` pointer file.
+
+---
+
+## 3. Architecture
+
+### 3.1 Layered design
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  User-facing commands & keymaps   (plugin/lazyhub.lua)   │
+├──────────────────────────────────────────────────────────┤
+│  Feature modules (lua/lazyhub/*.lua)                     │
+│    ├ float.lua        floating-terminal management        │
+│    ├ statusline.lua   status component for lualine etc.   │
+│    ├ review.lua       virtual text + reply UI             │
+│    ├ pickers.lua      snacks/telescope/fzf-lua shim       │
+│    ├ ipc.lua          NDJSON client + reconnect           │
+│    └ health.lua       :checkhealth lazyhub                │
+├──────────────────────────────────────────────────────────┤
+│  IPC transport (Unix socket)  ←→  lazyhub TUI process    │
+└──────────────────────────────────────────────────────────┘
+```
+
+### 3.2 Invariants
+
+1. **No GitHub HTTP calls in Lua.** All `gh` calls happen either in lazyhub (preferred) or via `vim.fn.jobstart({'gh', ...})` (when lazyhub isn't running). Never `curl`, never raw API tokens in Lua.
+2. **IPC is best-effort.** Every feature must degrade gracefully when lazyhub isn't running. If IPC is unavailable, fall back to spawning `gh` directly or showing a "lazyhub not running" notification.
+3. **No blocking calls in the main loop.** All `gh` and IPC calls use `vim.fn.jobstart` or `uv.new_pipe`. Never `vim.fn.system` for slow operations.
+4. **One installation, all distros.** Distro-specific code lives in `lua/lazyhub/distro/*.lua` and is loaded only when the distro is detected. The core works on plain nvim.
+5. **No keymap pollution.** The plugin registers `<Plug>(lazyhub-*)` mappings only. Users (or LazyExtras) bind them to `<leader>gh*`.
+
+---
+
+## 4. Phased delivery
+
+### Phase 1 — Ambient presence (1–2 days)
+
+Goal: lazyhub is *present* in the editor without opening the float.
+
+**1.1 Status line component** (`lua/lazyhub/statusline.lua`)
+
+Exports:
+```lua
+require('lazyhub.statusline').component()  -- returns string for lualine
+require('lazyhub.statusline').heirline()   -- returns component table for heirline
+```
+
+Displays for current branch:
+```
+ PR #123  ✓ CI  💬 2
+```
+
+- `` icon = no PR; ` PR #123` = PR linked
+- `✓/✗/●` for CI: passing / failing / running
+- `💬 N` = unresolved review threads (omitted if 0)
+- Pollable every 30s OR pushed via IPC `pr-state-changed` event (added below)
+
+Data source: IPC `state` request with `{ branch }` param. Lazyhub answers `{ prNumber, ciStatus, unresolvedThreads }`. If IPC down, fall back to `gh pr status --json ...` debounced to 60s.
+
+**1.2 Smart `:LazyHubPR`**
+
+If a PR exists for current branch:
+1. If lazyhub is running → IPC `navigate { prNumber: N, view: "diff" }`, then float
+2. If not running → spawn lazyhub with `GHUI_PR=N` env (requires new env handling in lazyhub bootstrap)
+
+If no PR: open lazyhub on the branch list.
+
+**1.3 LazyExtras module**
+
+Ship `integrations/nvim/lazyextras/init.lua` (separate from the plugin) that LazyVim users can enable via `:LazyExtras` → `tool.lazyhub`. It:
+- Imports `lazyhub`
+- Registers `<leader>gh*` keymaps under the `gh` which-key group
+- Configures lualine if installed
+
+**Acceptance:**
+- [ ] Status line component renders in lualine, heirline, and as a plain string
+- [ ] Component updates within 1s of `gh pr merge` completing
+- [ ] `:LazyHubPR` on a PR branch jumps to that PR's diff view
+- [ ] `:LazyExtras` shows `tool.lazyhub` as installable in LazyVim
+- [ ] All work degrades gracefully on plain nvim with no distro
+
+### Phase 2 — Inline reviews (3–5 days, the killer feature)
+
+Goal: review comments appear *next to the code being reviewed*, in the buffer, with reply-from-buffer.
+
+**2.1 Comment overlay** (`lua/lazyhub/review.lua`)
+
+When user runs `:LazyHubReview` (or `<leader>grr`):
+1. Resolve current PR via IPC `state` or `gh pr view --json`
+2. Fetch comments via `gh api repos/{r}/pulls/{n}/comments --jq '...'`
+3. For each comment whose `path` matches an open buffer:
+   - Set an extmark with virtual text on the comment's `line`
+   - Style: faded foreground, prefixed with `▎ @user:` and truncated to window width
+   - Add sign column marker (configurable: `█` default)
+4. Save `(bufnr, line) → comment` map for reply actions
+
+Multiple comments on the same line stack as virtual lines below the code line.
+
+**2.2 Reply / resolve from buffer**
+
+| Mapping | Action |
+|---|---|
+| `<leader>grr` | Refresh overlay |
+| `<leader>grR` | Reply to thread under cursor |
+| `<leader>grx` | Resolve thread under cursor |
+| `]r` / `[r` | Jump to next/prev review comment in buffer |
+
+Reply flow:
+1. Floating input prompt (`vim.ui.input` with multi-line via snacks.input if available)
+2. POST via `gh api graphql -F threadId=... -f body=...` (uses `addPullRequestReviewThreadReply` mutation)
+3. On success: re-fetch that thread, update the extmark, toast "Reply posted"
+4. On failure: keep buffer state, toast error
+
+**2.3 Live updates**
+
+Subscribe to IPC `review-comment-added` and `review-thread-resolved` events (added below). On event, patch the affected extmark without re-fetching everything.
+
+**2.4 Highlight groups**
+
+Define and expose:
+- `LazyhubReviewComment` (virtual text)
+- `LazyhubReviewSign` (sign column)
+- `LazyhubReviewAuthor` (author prefix)
+- `LazyhubReviewResolved` (resolved threads, dimmer)
+
+Link to sensible defaults (`Comment`, `DiagnosticInfo`) so themes work without configuration.
+
+**Acceptance:**
+- [ ] Open a PR's branch, run `:LazyHubReview` → review comments appear as virtual text on the right lines
+- [ ] Reply with `<leader>grR` → comment posts and overlay refreshes
+- [ ] Resolve with `<leader>grx` → thread dims, sign updates
+- [ ] `]r` / `[r` jump through comments in correct order
+- [ ] Comments survive `:e` (re-attached on `BufEnter`)
+- [ ] Live IPC events update overlays in <1s
+
+### Phase 3 — Pickers (2–3 days)
+
+Goal: fast list operations without opening the float.
+
+**3.1 Picker shim** (`lua/lazyhub/pickers.lua`)
+
+Auto-detect in priority order:
+1. `snacks.picker` (LazyVim 11+ default)
+2. `telescope.nvim`
+3. `fzf-lua`
+4. Fallback to `vim.ui.select`
+
+Exports `pick(items, opts)` returning the chosen item via callback.
+
+**3.2 Pickers shipped**
+
+| Command | Source | Default action | Alt actions |
+|---|---|---|---|
+| `:LazyHubPRs` | `gh pr list --json ...` | Open in float | `<C-o>` browser, `<C-y>` yank URL |
+| `:LazyHubIssues` | `gh issue list --json ...` | Open in float | same |
+| `:LazyHubChecks` | `gh pr checks` for current branch | Open log in split | `<C-r>` re-run check |
+| `:LazyHubNotifs` | `gh api notifications` | Open thread in float | `<C-d>` mark read |
+| `:LazyHubReviewers` | `gh api repos/{r}/collaborators` | Request reviewer for current PR | multi-select |
+
+Each list cached for 30s per repo to avoid spam during fuzzy typing.
+
+**Acceptance:**
+- [ ] All five pickers work on snacks, telescope, fzf-lua, and `vim.ui.select`
+- [ ] Default action opens the right pane in lazyhub
+- [ ] Cache invalidates on relevant IPC events (`pr-merged`, `pr-state-changed`)
+
+### Phase 4 — Distro packaging (1 day each)
+
+**4.1 LazyVim** — `LazyExtras` module submitted to `LazyVim/LazyVim` as `lua/lazyvim/plugins/extras/tool/lazyhub.lua`. Adds:
+- Plugin spec
+- `<leader>gh*` keymaps with which-key group
+- Lualine component if `lualine` loaded
+- Health check entry
+
+**4.2 AstroNvim** — PR to `AstroNvim/astrocommunity` under `lua/astrocommunity/git/lazyhub-nvim/`. Same surface adapted to AstroCore's `mappings` table.
+
+**4.3 NvChad** — README snippet only. NvChad users copy a chadrc.lua block. No upstream PR (NvChad's plugin model doesn't have a community repo equivalent).
+
+### Phase 5 — Polish
+
+- **snacks.terminal detection**: when `Snacks.terminal` exists, use it instead of `vim.fn.termopen` so float borders, win-options, and `q` behavior match the rest of LazyVim.
+- **which-key registration**: auto-register `<leader>gh` as group "lazyhub" with descriptions for each mapping.
+- **`:checkhealth lazyhub`**: verifies `gh` on PATH, `gh auth status` OK, lazyhub on PATH, socket reachable, detected picker/statusline backends, distro detection.
+- **IPC reconnect**: client retries connection with exponential backoff (1s → 30s cap) when socket disappears. On reconnect, re-subscribe to events.
+- **Configurable everything**: every keymap, sign character, highlight, and timeout overrideable via `setup({...})`.
+
+---
+
+## 5. IPC protocol additions
+
+The current `src/ipc.js` covers `ping`/`state`/`navigate`/`open-file`. To support the spec we need:
+
+### 5.1 New request types
+
+| Request | Params | Response |
+|---|---|---|
+| `state` (extended) | `{ branch?: string }` | `{ state: { pane, view, prNumber, repo, ciStatus, unresolvedThreads, branch } }` |
+| `pr-for-branch` | `{ branch }` | `{ prNumber, prState, ciStatus, unresolvedThreads }` or `{ prNumber: null }` |
+| `review-comments` | `{ prNumber }` | `{ comments: [{ id, threadId, path, line, body, user, resolved }] }` |
+| `reply-thread` | `{ threadId, body }` | `{ ok, commentId }` |
+| `resolve-thread` | `{ threadId }` | `{ ok }` |
+
+These are thin wrappers around existing executor calls so lazyhub's in-memory cache is reused (cheaper than nvim spawning `gh` again).
+
+### 5.2 New events
+
+| Event | Payload | Trigger |
+|---|---|---|
+| `pr-state-changed` | `{ branch, prNumber, ciStatus, unresolvedThreads }` | CI check refresh, PR open/merge/close |
+| `review-comment-added` | `{ prNumber, comment }` | Local action or polled refresh |
+| `review-thread-resolved` | `{ prNumber, threadId }` | Local action or polled refresh |
+| `branch-changed` | `{ repo, branch }` | User switches branch inside lazyhub |
+
+### 5.3 Constraints
+
+- All new handlers go through `executor.js` (project invariant — no `gh` outside executor)
+- Events are fire-and-forget; clients re-fetch on reconnect
+- Backwards compatible: unknown request types still return `{ error: "unknown type" }` — existing nvim plugin keeps working
+
+---
+
+## 6. File layout
+
+```
+integrations/nvim/
+├── plugin/
+│   └── lazyhub.lua              (existing, extended with new commands)
+├── lua/lazyhub/
+│   ├── init.lua                 (existing — setup(), config merging)
+│   ├── float.lua                (extracted from init.lua)
+│   ├── ipc.lua                  (extracted from init.lua, + reconnect)
+│   ├── statusline.lua           NEW — Phase 1
+│   ├── review.lua               NEW — Phase 2
+│   ├── pickers.lua              NEW — Phase 3
+│   ├── health.lua               NEW — Phase 5
+│   └── distro/
+│       ├── lazyvim.lua          NEW — detection + integration hooks
+│       ├── astronvim.lua        NEW
+│       └── nvchad.lua           NEW
+├── lazyextras/
+│   └── lazyhub.lua              NEW — copyable into LazyVim/LazyVim PR
+└── README.md                    UPDATE — install per distro, all commands
+```
+
+---
+
+## 7. Test plan
+
+### Unit (busted, in `integrations/nvim/tests/`)
+
+- `ipc_spec.lua` — NDJSON framing, reconnect, request/response correlation
+- `statusline_spec.lua` — component renders for each PR state
+- `review_spec.lua` — comment-to-extmark mapping, reply payload shape
+- `pickers_spec.lua` — backend detection priority
+
+### Integration (manual, captured in `MANUAL_TEST_PLAN.md`)
+
+- Plain nvim install (no distro) — all commands work
+- LazyVim with `tool.lazyhub` extra — keymaps appear in which-key
+- AstroNvim with astrocommunity entry — same surface
+- IPC disconnect mid-review → reconnects, comments still visible
+
+### CI
+
+- Add `nvim --headless -c "PlenaryBustedDirectory tests/" -c "qa!"` to existing test workflow
+- Matrix: nvim 0.9, 0.10, nightly
+
+---
+
+## 8. Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Each distro's API shifts (LazyExtras path, snacks.picker) | Distro detection in `lua/lazyhub/distro/`; one file per distro, easy to patch |
+| Heavy `gh api` polling drains rate limit | Cache 30s per repo; prefer IPC state from lazyhub; respect `X-RateLimit-Remaining` header |
+| Virtual text conflicts with other plugins (gitsigns, lsp) | Dedicated namespace `lazyhub.review`; only set on `BufEnter` after user opt-in; never auto-attach |
+| IPC socket race when user runs two lazyhub instances | Pointer file stores newest; old instance's socket still works for already-connected clients |
+| `vim.fn.system` blocking the UI | Code review: forbid `vim.fn.system` for any call slower than 50ms; lint via grep in CI |
+
+---
+
+## 9. Out of scope (explicitly)
+
+- PRs as nvim buffers (octo.nvim's model) — duplicates the TUI
+- Issue creation/edit from nvim — low frequency
+- Self-hosted GHE auth flow (works automatically via `gh auth`, no plugin work needed)
+- Telemetry / opt-in metrics
+- AI review actions in nvim (handled by `AI_PROVIDERS_SPEC.md`)
+
+---
+
+## 10. Open questions
+
+1. **Snacks integration depth.** Should the float *require* snacks when LazyVim is detected, or always remain optional? Recommendation: optional with auto-upgrade.
+2. **GHE / self-hosted.** Confirm IPC events fire correctly when `GH_HOST` is set (existing test failure noted in memory may matter).
+3. **Reply UX on monitor-narrow setups.** `vim.ui.input` is single-line. Multi-line replies via `snacks.input` or a scratch buffer? Recommendation: scratch buffer with `<C-s>` to send, `q` to cancel.

--- a/integrations/nvim/lazyextras/lazyhub.lua
+++ b/integrations/nvim/lazyextras/lazyhub.lua
@@ -1,0 +1,110 @@
+--[[
+  lazyhub LazyExtras module
+  =========================
+  This file is a COPY-PASTE TARGET — it is NOT auto-loaded by the lazyhub plugin.
+
+  To use it, either:
+    a) Drop it into LazyVim's extras directory as:
+         ~/.config/nvim/lua/plugins/extras/tool/lazyhub.lua
+       then enable via :LazyExtras → tool.lazyhub
+
+    b) Paste the contents into your own plugins/ config file.
+
+  This file will eventually be submitted upstream to LazyVim/LazyVim as:
+    lua/lazyvim/plugins/extras/tool/lazyhub.lua
+
+  Source repo: https://github.com/saketh-kowtha/lazyhub
+  Plugin subdir: integrations/nvim  (the plugin lives inside the monorepo)
+--]]
+
+return {
+  -- ─── Plugin spec ────────────────────────────────────────────────────────────
+  {
+    'saketh-kowtha/lazyhub',
+    -- The nvim plugin lives in a subdirectory of the monorepo.
+    -- lazy.nvim ≥ 11 supports `subdir` natively; older versions need `dir`.
+    subdir = 'integrations/nvim',
+
+    cmd = {
+      'LazyHub',
+      'LazyHubPR',
+      'LazyHubBlame',
+      'LazyHubDiag',
+      'LazyHubState',
+    },
+
+    keys = {
+      -- which-key group label
+      { '<leader>gh',  group = 'lazyhub' },
+
+      -- Individual commands
+      { '<leader>gho', '<cmd>LazyHub<cr>',       desc = 'Open lazyhub' },
+      { '<leader>ghp', '<cmd>LazyHubPR<cr>',     desc = 'Open PR for current branch' },
+      { '<leader>ghb', '<cmd>LazyHubBlame<cr>',  desc = 'Open PR for line under cursor' },
+      { '<leader>ghd', '<cmd>LazyHubDiag<cr>',   desc = 'Load PR review comments as diagnostics' },
+      { '<leader>ghs', '<cmd>LazyHubState<cr>',  desc = 'Show lazyhub IPC state' },
+    },
+
+    opts = {
+      -- Floating window options (passed to require('lazyhub').setup())
+      width     = 0.9,
+      height    = 0.9,
+      border    = 'rounded',
+      close_key = '<C-q>',
+    },
+
+    config = function(_, opts)
+      require('lazyhub').setup(opts)
+
+      -- Kick off the statusline poller.
+      -- The component is exposed for manual wiring — see lualine snippet below.
+      require('lazyhub.statusline').setup()
+    end,
+  },
+
+  -- ─── lualine integration (optional) ─────────────────────────────────────────
+  --
+  -- If you use lualine, add the component to your lualine config.
+  -- Example — add to your existing lualine setup() call:
+  --
+  --   require('lualine').setup({
+  --     sections = {
+  --       lualine_b = {
+  --         'branch',
+  --         -- lazyhub PR status:
+  --         { function() return require('lazyhub.statusline').component() end,
+  --           cond = function() return require('lazyhub.statusline').component() ~= '' end },
+  --       },
+  --     },
+  --   })
+  --
+  -- LazyVim users can extend lualine opts using the LazyVim.lualine helper:
+  --
+  --   {
+  --     'nvim-lualine/lualine.nvim',
+  --     optional = true,
+  --     opts = function(_, opts)
+  --       table.insert(opts.sections.lualine_b, {
+  --         function() return require('lazyhub.statusline').component() end,
+  --         cond = function() return require('lazyhub.statusline').component() ~= '' end,
+  --       })
+  --       return opts
+  --     end,
+  --   },
+  --
+  -- Uncomment the block below to enable the lualine integration automatically:
+  --
+  -- {
+  --   'nvim-lualine/lualine.nvim',
+  --   optional = true,
+  --   opts = function(_, opts)
+  --     opts.sections = opts.sections or {}
+  --     opts.sections.lualine_b = opts.sections.lualine_b or {}
+  --     table.insert(opts.sections.lualine_b, {
+  --       function() return require('lazyhub.statusline').component() end,
+  --       cond = function() return require('lazyhub.statusline').component() ~= '' end,
+  --     })
+  --     return opts
+  --   end,
+  -- },
+}

--- a/integrations/nvim/lua/lazyhub/float.lua
+++ b/integrations/nvim/lua/lazyhub/float.lua
@@ -1,0 +1,56 @@
+-- lazyhub.float — floating terminal window management
+--
+-- Extracted from init.lua so other modules can open the lazyhub float
+-- without requiring all of init.lua.
+
+local M = {}
+
+-- Reference to the parent config; set by init.lua after setup().
+M._config = nil
+
+--- Open a floating terminal running `cmd`.
+--- Falls back to sensible defaults when _config is not yet set.
+--- @param cmd string  shell command to run inside the float
+--- @return number  window id
+function M.open_float(cmd)
+  local cfg = M._config or {
+    width  = 0.9,
+    height = 0.9,
+    border = 'rounded',
+    close_key = '<C-q>',
+  }
+
+  local width  = cfg.width  <= 1 and math.floor(vim.o.columns * cfg.width)  or cfg.width
+  local height = cfg.height <= 1 and math.floor(vim.o.lines   * cfg.height) or cfg.height
+  local row    = math.floor((vim.o.lines   - height) / 2)
+  local col    = math.floor((vim.o.columns - width)  / 2)
+
+  local buf = vim.api.nvim_create_buf(false, true)
+  local win = vim.api.nvim_open_win(buf, true, {
+    relative  = 'editor',
+    width     = width,
+    height    = height,
+    row       = row,
+    col       = col,
+    style     = 'minimal',
+    border    = cfg.border,
+    title     = ' lazyhub ',
+    title_pos = 'center',
+  })
+
+  vim.fn.termopen(cmd, {
+    on_exit = function()
+      if vim.api.nvim_win_is_valid(win) then
+        vim.api.nvim_win_close(win, true)
+      end
+    end,
+  })
+
+  vim.api.nvim_buf_set_keymap(buf, 't', cfg.close_key,
+    '<C-\\><C-n>:close<CR>', { noremap = true, silent = true })
+
+  vim.cmd('startinsert')
+  return win
+end
+
+return M

--- a/integrations/nvim/lua/lazyhub/init.lua
+++ b/integrations/nvim/lua/lazyhub/init.lua
@@ -3,7 +3,7 @@
 --
 -- Features:
 --   :LazyHub              open lazyhub in a floating terminal
---   :LazyHubPR            open lazyhub focused on PR for current branch
+--   :LazyHubPR            smart open: jumps to the PR for the current branch
 --   :LazyHubBlame         open PR that introduced the line under cursor
 --   :LazyHubDiagnostics   load PR review comments as vim diagnostics
 --   :LazyHubState         show current lazyhub IPC state
@@ -33,96 +33,10 @@ M.config = {
   auto_diagnostics = false,
 }
 
--- ─── Helpers ──────────────────────────────────────────────────────────────────
+-- ─── Sub-module references (extracted, loaded lazily) ────────────────────────
 
-local function socket_path()
-  local pointer = vim.fn.expand('~/.lazyhub-socket')
-  if vim.fn.filereadable(pointer) == 1 then
-    return vim.fn.readfile(pointer)[1]
-  end
-  return nil
-end
-
---- Send a request to a running lazyhub IPC server.
---- @param msg table   request object
---- @param cb  function(response|nil)  callback
-local function ipc_send(msg, cb)
-  local path = socket_path()
-  if not path or vim.fn.filereadable(path) == 0 then
-    if cb then cb(nil) end
-    return
-  end
-
-  msg.id = tostring(math.random(1e9))
-  local json = vim.json.encode(msg) .. '\n'
-
-  local ok, uv = pcall(require, 'luv')
-  if not ok then uv = vim.uv or vim.loop end
-
-  local client = uv.new_pipe(false)
-  local buf = ''
-
-  client:connect(path, function(err)
-    if err then
-      client:close()
-      if cb then vim.schedule(function() cb(nil) end) end
-      return
-    end
-    client:write(json)
-    client:read_start(function(rerr, data)
-      if rerr or not data then
-        client:close()
-        return
-      end
-      buf = buf .. data
-      for line in buf:gmatch('[^\n]+') do
-        local ok2, parsed = pcall(vim.json.decode, line)
-        if ok2 and parsed.id == msg.id then
-          client:close()
-          if cb then vim.schedule(function() cb(parsed) end) end
-          return
-        end
-      end
-    end)
-  end)
-end
-
---- Create a floating terminal window running `cmd`.
---- Returns the window id.
-local function open_float(cmd)
-  local width  = M.config.width  <= 1 and math.floor(vim.o.columns * M.config.width)  or M.config.width
-  local height = M.config.height <= 1 and math.floor(vim.o.lines   * M.config.height) or M.config.height
-  local row    = math.floor((vim.o.lines   - height) / 2)
-  local col    = math.floor((vim.o.columns - width)  / 2)
-
-  local buf = vim.api.nvim_create_buf(false, true)
-  local win = vim.api.nvim_open_win(buf, true, {
-    relative = 'editor',
-    width    = width,
-    height   = height,
-    row      = row,
-    col      = col,
-    style    = 'minimal',
-    border   = M.config.border,
-    title    = ' lazyhub ',
-    title_pos = 'center',
-  })
-
-  vim.fn.termopen(cmd, {
-    on_exit = function()
-      if vim.api.nvim_win_is_valid(win) then
-        vim.api.nvim_win_close(win, true)
-      end
-    end,
-  })
-
-  -- Close keybinding inside the terminal buffer
-  vim.api.nvim_buf_set_keymap(buf, 't', M.config.close_key,
-    '<C-\\><C-n>:close<CR>', { noremap = true, silent = true })
-
-  vim.cmd('startinsert')
-  return win
-end
+local function _ipc()  return require('lazyhub.ipc')  end
+local function _float() return require('lazyhub.float') end
 
 -- ─── Commands ─────────────────────────────────────────────────────────────────
 
@@ -130,24 +44,69 @@ end
 function M.open(opts)
   opts = opts or {}
   local cmd = 'lazyhub'
-  -- Pass current repo via env if not already set
   local repo_env = ''
   if opts.repo then
     repo_env = 'GHUI_REPO=' .. opts.repo .. ' '
   end
-  open_float(repo_env .. cmd)
+  _float().open_float(repo_env .. cmd)
 end
 
---- Open lazyhub focused on the PR for the current git branch.
+--- Smart open: if a PR exists for the current branch, navigate to it.
+--- Behavior:
+---   1. Query IPC pr-for-branch with the current branch name.
+---   2a. If a PR is found AND lazyhub is running:
+---       send navigate { view='diff', prNumber=N }, then open the float.
+---   2b. If a PR is found AND lazyhub is NOT running:
+---       spawn lazyhub with GHUI_PR=N env (requires lazyhub bootstrap to honour it;
+---       if not supported, lazyhub opens normally — graceful degradation).
+---   3. If no PR: open lazyhub on the default PR list.
 function M.open_pr()
   local branch = vim.fn.system('git rev-parse --abbrev-ref HEAD 2>/dev/null'):gsub('%s+$', '')
   if branch == '' or branch == 'HEAD' then
     vim.notify('[lazyhub] not in a git repo or detached HEAD', vim.log.levels.WARN)
     return
   end
-  -- Open lazyhub — it will auto-detect the repo; user navigates to the PR
-  -- In the future this can be wired to IPC navigate once lazyhub supports branch→PR lookup
-  M.open({ branch = branch })
+
+  -- Ask IPC for the PR associated with this branch
+  _ipc().request({ type = 'pr-for-branch', branch = branch }, function(resp)
+    local pr_num = resp and resp.prNumber
+
+    if pr_num then
+      -- lazyhub is running (IPC responded) — navigate to diff view, then open float
+      _ipc().request({ type = 'navigate', view = 'diff', prNumber = pr_num }, function()
+        M.open()
+      end)
+    else
+      -- IPC unavailable or no PR: fall back to gh pr list directly
+      vim.fn.jobstart(
+        { 'gh', 'pr', 'list', '--head', branch, '--json', 'number', '--limit', '1' },
+        {
+          stdout_buffered = true,
+          on_stdout = function(_, data)
+            local json = table.concat(data, '')
+            local ok, parsed = pcall(vim.json.decode, json)
+            local fallback_num = ok and type(parsed) == 'table' and parsed[1] and parsed[1].number
+
+            if fallback_num then
+              -- lazyhub not running — spawn with GHUI_PR env for initial navigation
+              -- Note: lazyhub bootstrap will honour GHUI_PR once that env var is wired;
+              -- until then it opens normally (graceful degradation per invariant 2).
+              _float().open_float('GHUI_PR=' .. tostring(fallback_num) .. ' lazyhub')
+            else
+              -- No PR for this branch — open lazyhub on the PR list
+              M.open()
+            end
+          end,
+          on_exit = function(_, code)
+            if code ~= 0 then
+              -- gh not available or error — just open lazyhub normally
+              M.open()
+            end
+          end,
+        }
+      )
+    end
+  end)
 end
 
 --- Open lazyhub and navigate to the PR that introduced the line under the cursor
@@ -165,7 +124,6 @@ function M.blame_pr()
     return
   end
 
-  -- Try to find a PR number from the commit message or gh CLI
   vim.fn.jobstart(
     { 'gh', 'pr', 'list', '--search', sha, '--json', 'number', '--jq', '.[0].number' },
     {
@@ -173,7 +131,7 @@ function M.blame_pr()
       on_stdout = function(_, data)
         local pr_num = tonumber((data[1] or ''):gsub('%s+', ''))
         if pr_num then
-          ipc_send({ type = 'navigate', prNumber = pr_num }, function()
+          _ipc().request({ type = 'navigate', prNumber = pr_num }, function()
             M.open()
           end)
         else
@@ -188,7 +146,7 @@ end
 --- Load PR review comments as Neovim diagnostics.
 --- Requires a running lazyhub instance (for IPC state) or falls back to gh CLI.
 function M.load_diagnostics()
-  ipc_send({ type = 'state' }, function(resp)
+  _ipc().request({ type = 'state' }, function(resp)
     local pr_number = resp and resp.state and resp.state.prNumber
     if not pr_number then
       vim.notify('[lazyhub] no PR open in lazyhub', vim.log.levels.INFO)
@@ -209,10 +167,8 @@ function M.load_diagnostics()
           local ok, comments = pcall(vim.json.decode, json)
           if not ok or type(comments) ~= 'table' then return end
 
-          -- Clear existing diagnostics
           vim.diagnostic.reset(M.config.diagnostics_ns)
 
-          -- Group comments by file
           local by_file = {}
           for _, c in ipairs(comments) do
             if c.path and c.line then
@@ -221,17 +177,15 @@ function M.load_diagnostics()
             end
           end
 
-          -- Set diagnostics on each open buffer
           for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
             if not vim.api.nvim_buf_is_loaded(bufnr) then goto continue end
             local bufpath = vim.api.nvim_buf_get_name(bufnr)
-            -- Match on the filename portion (PR paths are relative to repo root)
             for file_path, file_comments in pairs(by_file) do
               if bufpath:find(file_path, 1, true) then
                 local diags = {}
                 for _, c in ipairs(file_comments) do
                   table.insert(diags, {
-                    lnum     = (c.line or 1) - 1,  -- 0-indexed
+                    lnum     = (c.line or 1) - 1,
                     col      = 0,
                     severity = vim.diagnostic.severity.INFO,
                     message  = string.format('[%s] %s', c.user or 'reviewer', c.body or ''),
@@ -255,7 +209,7 @@ end
 
 --- Show current lazyhub IPC state in a floating notification.
 function M.show_state()
-  ipc_send({ type = 'state' }, function(resp)
+  _ipc().request({ type = 'state' }, function(resp)
     if not resp or not resp.state then
       vim.notify('[lazyhub] not running or IPC unavailable', vim.log.levels.WARN)
       return
@@ -268,7 +222,6 @@ function M.show_state()
       s.prNumber    and string.format('PR:    #%d', s.prNumber)    or nil,
       s.issueNumber and string.format('issue: #%d', s.issueNumber) or nil,
     }
-    -- Filter nils
     local filtered = {}
     for _, l in ipairs(lines) do if l then table.insert(filtered, l) end end
     vim.notify(table.concat(filtered, '\n'), vim.log.levels.INFO, { title = 'lazyhub state' })
@@ -280,13 +233,15 @@ end
 function M.setup(opts)
   M.config = vim.tbl_deep_extend('force', M.config, opts or {})
 
-  vim.api.nvim_create_user_command('LazyHub',          function() M.open() end,         { desc = 'Open lazyhub' })
-  vim.api.nvim_create_user_command('LazyHubPR',        function() M.open_pr() end,      { desc = 'Open lazyhub for current branch PR' })
-  vim.api.nvim_create_user_command('LazyHubBlame',     function() M.blame_pr() end,     { desc = 'Open PR that introduced line under cursor' })
-  vim.api.nvim_create_user_command('LazyHubDiag',      function() M.load_diagnostics() end, { desc = 'Load PR review comments as diagnostics' })
-  vim.api.nvim_create_user_command('LazyHubState',     function() M.show_state() end,   { desc = 'Show current lazyhub IPC state' })
+  -- Propagate config to float module so open_float() uses the user's settings
+  _float()._config = M.config
 
-  -- Auto-load diagnostics on BufEnter if enabled
+  vim.api.nvim_create_user_command('LazyHub',      function() M.open() end,            { desc = 'Open lazyhub' })
+  vim.api.nvim_create_user_command('LazyHubPR',    function() M.open_pr() end,         { desc = 'Open lazyhub for current branch PR' })
+  vim.api.nvim_create_user_command('LazyHubBlame', function() M.blame_pr() end,        { desc = 'Open PR that introduced line under cursor' })
+  vim.api.nvim_create_user_command('LazyHubDiag',  function() M.load_diagnostics() end, { desc = 'Load PR review comments as diagnostics' })
+  vim.api.nvim_create_user_command('LazyHubState', function() M.show_state() end,      { desc = 'Show current lazyhub IPC state' })
+
   if M.config.auto_diagnostics then
     vim.api.nvim_create_autocmd('BufEnter', {
       group = vim.api.nvim_create_augroup('lazyhub_auto_diag', { clear = true }),

--- a/integrations/nvim/lua/lazyhub/ipc.lua
+++ b/integrations/nvim/lua/lazyhub/ipc.lua
@@ -1,0 +1,118 @@
+-- lazyhub.ipc — NDJSON Unix-socket client with exponential-backoff reconnect
+--
+-- Public API:
+--   require('lazyhub.ipc').request(msg, cb)  — send a request, receive response via cb(resp|nil)
+--   require('lazyhub.ipc').connect()         — (re)connect to the IPC socket; called automatically
+--
+-- Reconnect invariant (spec §3.2 invariant 2):
+--   If the socket path is not reachable, every feature degrades gracefully.
+--   The module retries with exponential backoff: 1s → 2s → 4s … capped at 30s.
+--   On successful connect the backoff resets.
+
+local M = {}
+
+-- ─── Helpers ─────────────────────────────────────────────────────────────────
+
+local function socket_path()
+  local pointer = vim.fn.expand('~/.lazyhub-socket')
+  if vim.fn.filereadable(pointer) == 1 then
+    return vim.fn.readfile(pointer)[1]
+  end
+  return nil
+end
+
+-- ─── Reconnect state ─────────────────────────────────────────────────────────
+
+local _retry_delay  = 1    -- seconds; doubles on each failure, capped at 30
+local _retry_timer  = nil
+
+local function _schedule_reconnect()
+  if _retry_timer then return end -- already pending
+  _retry_timer = vim.defer_fn(function()
+    _retry_timer = nil
+    M.connect()
+  end, _retry_delay * 1000)
+  _retry_delay = math.min(_retry_delay * 2, 30)
+end
+
+-- Reset backoff on successful operation
+local function _reset_backoff()
+  _retry_delay = 1
+  if _retry_timer then
+    -- cancel pending retry
+    pcall(function()
+      local uv = (vim.uv or vim.loop)
+      -- vim.defer_fn uses a libuv timer internally; we can't cancel it by handle
+      -- so we just let it fire harmlessly (connect() is idempotent when socket exists)
+    end)
+  end
+end
+
+-- ─── request() ───────────────────────────────────────────────────────────────
+
+--- Send a request to a running lazyhub IPC server.
+--- Non-blocking: uses libuv pipes. Calls cb(response|nil) on vim.schedule().
+--- @param msg  table   request object (id will be set automatically)
+--- @param cb   function(response|nil)
+function M.request(msg, cb)
+  local path = socket_path()
+  if not path or vim.fn.filereadable(path) == 0 then
+    _schedule_reconnect()
+    if cb then vim.schedule(function() cb(nil) end) end
+    return
+  end
+
+  msg.id = tostring(math.random(1e9))
+  local json = vim.json.encode(msg) .. '\n'
+
+  local ok, uv = pcall(require, 'luv')
+  if not ok then uv = vim.uv or vim.loop end
+
+  local client = uv.new_pipe(false)
+  local buf = ''
+
+  client:connect(path, function(err)
+    if err then
+      client:close()
+      _schedule_reconnect()
+      if cb then vim.schedule(function() cb(nil) end) end
+      return
+    end
+
+    _reset_backoff()
+    client:write(json)
+    client:read_start(function(rerr, data)
+      if rerr or not data then
+        client:close()
+        return
+      end
+      buf = buf .. data
+      for line in buf:gmatch('[^\n]+') do
+        local ok2, parsed = pcall(vim.json.decode, line)
+        if ok2 and parsed.id == msg.id then
+          client:close()
+          if cb then vim.schedule(function() cb(parsed) end) end
+          return
+        end
+      end
+    end)
+  end)
+end
+
+--- Attempt a connection (used by reconnect logic).
+--- No-op when the socket is already reachable.
+function M.connect()
+  local path = socket_path()
+  if not path then
+    _schedule_reconnect()
+    return
+  end
+  -- Verify reachable with a ping; resets backoff on success
+  M.request({ type = 'ping' }, function(resp)
+    if not resp then
+      _schedule_reconnect()
+    end
+  end)
+end
+
+return M

--- a/integrations/nvim/lua/lazyhub/statusline.lua
+++ b/integrations/nvim/lua/lazyhub/statusline.lua
@@ -1,0 +1,255 @@
+-- lazyhub.statusline — ambient PR status component for lualine / heirline
+--
+-- Exports:
+--   require('lazyhub.statusline').setup(opts)     — kick off polling + IPC subscription
+--   require('lazyhub.statusline').component()     — returns string for lualine
+--   require('lazyhub.statusline').heirline()      — returns component table for heirline
+--   require('lazyhub.statusline').state()         — returns raw cached state table
+--
+-- Display format (when a PR exists):
+--   " PR #123  ✓ CI  💬 2"
+--   Icon:   (nf-oct-git-pull-request — same glyph lazyhub uses in TUI)
+--   CI:    ✓ pass / ✗ fail / ● pending / (omitted when null)
+--   Threads: 💬 N (omitted when 0 or null)
+--   When no PR: empty string (lualine hides the segment automatically)
+--
+-- Data sources (in priority order):
+--   1. IPC `pr-for-branch` request (when lazyhub is running)
+--   2. Fallback: `gh pr list --head <branch> --json ...` via vim.fn.jobstart
+--
+-- Polling:
+--   - Every 30 seconds unconditionally
+--   - On BufEnter (debounced 5 s) so the indicator refreshes as you navigate files
+--   - Immediately on IPC `pr-state-changed` events (for the matching branch)
+
+local M = {}
+
+-- ─── Constants ────────────────────────────────────────────────────────────────
+
+-- nf-oct-git-pull-request (U+F407).  Verified: same codepoint grep returns for
+-- TUI nerd-font usage in this codebase.
+local PR_ICON = '\u{f407}'
+
+local CI_ICONS = {
+  pass    = '✓',
+  fail    = '✗',
+  pending = '●',
+}
+
+local POLL_INTERVAL_MS  = 30 * 1000   -- 30 s
+local BUFENTER_DEBOUNCE = 5 * 1000    -- 5 s
+
+-- ─── Internal state ──────────────────────────────────────────────────────────
+
+local _cache = {
+  prNumber         = nil,
+  prState          = nil,
+  ciStatus         = nil,
+  unresolvedThreads = nil,
+}
+
+local _last_branch      = nil    -- branch used for the last successful fetch
+local _debounce_timer   = nil    -- luv timer for BufEnter debounce
+local _poll_timer       = nil    -- luv timer for 30-s interval
+local _initialized      = false
+
+-- ─── Helpers ─────────────────────────────────────────────────────────────────
+
+local function current_branch()
+  -- vim.fn.system is acceptable for fast git reads (spec invariant 3 caveat)
+  local b = vim.fn.system('git rev-parse --abbrev-ref HEAD 2>/dev/null'):gsub('%s+$', '')
+  if b == '' or b == 'HEAD' then return nil end
+  return b
+end
+
+local function update_cache(data)
+  if not data then return end
+  _cache.prNumber          = data.prNumber or nil
+  _cache.prState           = data.prState  or nil
+  _cache.ciStatus          = data.ciStatus or nil
+  _cache.unresolvedThreads = data.unresolvedThreads or nil
+end
+
+-- ─── Fallback: gh pr list via jobstart ───────────────────────────────────────
+
+local function fetch_via_gh(branch)
+  if not branch then return end
+  vim.fn.jobstart(
+    { 'gh', 'pr', 'list', '--head', branch,
+      '--json', 'number,state,statusCheckRollup,reviewThreads',
+      '--limit', '1' },
+    {
+      stdout_buffered = true,
+      on_stdout = function(_, data)
+        local json = table.concat(data, '')
+        if json == '' then return end
+        local ok, parsed = pcall(vim.json.decode, json)
+        if not ok or type(parsed) ~= 'table' then return end
+
+        if #parsed == 0 then
+          update_cache({ prNumber = nil })
+          return
+        end
+
+        local pr = parsed[1]
+
+        -- Map statusCheckRollup array → ciStatus string
+        local ci_status = nil
+        local rollup = pr.statusCheckRollup
+        if type(rollup) == 'table' then
+          local has_fail, has_pending, all_pass = false, false, true
+          for _, c in ipairs(rollup) do
+            local s = ((c.conclusion or c.state or ''):upper())
+            if s == 'FAILURE' or s == 'ERROR' or s == 'TIMED_OUT' or s == 'CANCELLED' then
+              has_fail = true; all_pass = false
+            elseif s ~= 'SUCCESS' then
+              has_pending = true; all_pass = false
+            end
+          end
+          if has_fail then ci_status = 'fail'
+          elseif has_pending then ci_status = 'pending'
+          elseif all_pass and #rollup > 0 then ci_status = 'pass'
+          end
+        end
+
+        -- Count unresolved review threads
+        local unresolved = nil
+        if type(pr.reviewThreads) == 'table' then
+          local n = 0
+          for _, t in ipairs(pr.reviewThreads) do
+            if t.isResolved == false then n = n + 1 end
+          end
+          if n > 0 then unresolved = n end
+        end
+
+        update_cache({
+          prNumber          = pr.number,
+          prState           = pr.state,
+          ciStatus          = ci_status,
+          unresolvedThreads = unresolved,
+        })
+      end,
+    }
+  )
+end
+
+-- ─── Primary fetch via IPC ────────────────────────────────────────────────────
+
+local function fetch(branch)
+  branch = branch or current_branch()
+  if not branch then return end
+  _last_branch = branch
+
+  local ipc = require('lazyhub.ipc')
+  ipc.request({ type = 'pr-for-branch', branch = branch }, function(resp)
+    if resp and resp.prNumber ~= nil then
+      -- IPC responded (even prNumber=null is a valid authoritative answer)
+      update_cache(resp)
+    else
+      -- IPC unavailable — fall back to gh
+      fetch_via_gh(branch)
+    end
+  end)
+end
+
+-- ─── Polling timers ──────────────────────────────────────────────────────────
+
+local function start_poll_timer()
+  if _poll_timer then return end
+  local uv = vim.uv or vim.loop
+  _poll_timer = uv.new_timer()
+  _poll_timer:start(POLL_INTERVAL_MS, POLL_INTERVAL_MS, vim.schedule_wrap(function()
+    fetch()
+  end))
+end
+
+local function schedule_bufenter_fetch()
+  local uv = vim.uv or vim.loop
+  if _debounce_timer then
+    _debounce_timer:stop()
+  else
+    _debounce_timer = uv.new_timer()
+  end
+  _debounce_timer:start(BUFENTER_DEBOUNCE, 0, vim.schedule_wrap(function()
+    fetch()
+  end))
+end
+
+-- ─── Public API ──────────────────────────────────────────────────────────────
+
+--- Returns the raw cached state table.
+--- @return table  { prNumber, prState, ciStatus, unresolvedThreads }
+function M.state()
+  return vim.deepcopy(_cache)
+end
+
+--- Returns a plain string for lualine (or any statusline using tostring).
+--- Empty string when no PR is open (lualine hides the segment).
+--- @return string
+function M.component()
+  local s = _cache
+  if not s.prNumber then return '' end
+
+  local parts = { PR_ICON .. ' PR #' .. tostring(s.prNumber) }
+
+  if s.ciStatus then
+    local icon = CI_ICONS[s.ciStatus]
+    if icon then
+      table.insert(parts, ' ' .. icon .. ' CI')
+    end
+  end
+
+  if s.unresolvedThreads and s.unresolvedThreads > 0 then
+    table.insert(parts, '  \xf0\x9f\x92\xac ' .. tostring(s.unresolvedThreads))
+  end
+
+  return table.concat(parts, '')
+end
+
+--- Returns a heirline component table.
+--- @return table  heirline component spec
+function M.heirline()
+  return {
+    provider = function() return M.component() end,
+    hl       = function()
+      local s = _cache
+      if s.ciStatus == 'fail' then
+        return { fg = 'DiagnosticError' }
+      elseif s.ciStatus == 'pass' then
+        return { fg = 'DiagnosticOk' }
+      end
+      return {}
+    end,
+    update   = { 'User', pattern = 'LazyhubStatusUpdate' },
+  }
+end
+
+--- Kick off polling and IPC subscription.
+--- Call this from your init / config (e.g. require('lazyhub.statusline').setup()).
+--- @param opts? table  (reserved for future options; unused in Phase 1)
+function M.setup(opts)
+  if _initialized then return end
+  _initialized = true
+
+  -- Initial fetch
+  fetch()
+
+  -- 30-s poll timer
+  start_poll_timer()
+
+  -- BufEnter re-poll (debounced 5 s)
+  vim.api.nvim_create_autocmd('BufEnter', {
+    group    = vim.api.nvim_create_augroup('lazyhub_statusline', { clear = true }),
+    callback = function() schedule_bufenter_fetch() end,
+  })
+
+  -- IPC pr-state-changed event subscription.
+  -- The IPC module delivers server-push events as raw NDJSON lines; for Phase 1
+  -- we rely on polling and the BufEnter debounce.  When a lazyhub build that emits
+  -- pr-state-changed lands, this autocmd will fire on the User event published below.
+  -- For now, any code that calls emitIPC('pr-state-changed', payload) from the TUI
+  -- will reach connected clients via the socket.  The Lua side receives it as part of
+  -- a future long-lived socket subscription (Phase 2); in Phase 1 polling covers it.
+end
+
+return M

--- a/src/executor.js
+++ b/src/executor.js
@@ -817,6 +817,87 @@ export async function resolveThread(threadId) {
 }
 
 /**
+ * Get PR state for a given branch head ref.
+ *
+ * Runs `gh pr list --head <branch>` and maps the first result to the IPC
+ * response shape expected by the nvim statusline.
+ *
+ * CI status mapping:
+ *   SUCCESS          → 'pass'
+ *   FAILURE / ERROR  → 'fail'
+ *   anything else    → 'pending'
+ *   missing          → null
+ *
+ * @param {string} branch  - head ref name (e.g. 'feat/my-feature')
+ * @param {string} [repo]  - optional repo override; falls back to GHUI_REPO
+ * @returns {Promise<{prNumber:number|null, prState?:string, ciStatus?:string|null, unresolvedThreads?:number}>}
+ */
+export async function getPRStateForBranch(branch, repo) {
+  if (!branch) return { prNumber: null }
+
+  const args = [
+    'pr', 'list',
+    '--head', branch,
+    '--json', 'number,state,statusCheckRollup,reviewThreads',
+    '--limit', '1',
+  ]
+
+  if (repo || process.env.GHUI_REPO) {
+    args.push('--repo', getRepo(repo))
+  }
+
+  let results
+  try {
+    results = await run(args)
+  } catch {
+    // If the call fails (e.g. no remote, rate-limit), degrade gracefully.
+    return { prNumber: null }
+  }
+
+  if (!Array.isArray(results) || results.length === 0) {
+    return { prNumber: null }
+  }
+
+  const pr = results[0]
+
+  // Map statusCheckRollup to ciStatus
+  let ciStatus = null
+  const rollup = pr.statusCheckRollup
+  if (Array.isArray(rollup) && rollup.length > 0) {
+    // Rollup is an array of check objects; derive overall status from the worst conclusion
+    const conclusions = rollup.map(c => (c.conclusion || c.state || '').toUpperCase())
+    if (conclusions.some(c => c === 'FAILURE' || c === 'ERROR' || c === 'TIMED_OUT' || c === 'CANCELLED')) {
+      ciStatus = 'fail'
+    } else if (conclusions.every(c => c === 'SUCCESS')) {
+      ciStatus = 'pass'
+    } else {
+      ciStatus = 'pending'
+    }
+  } else if (typeof rollup === 'string') {
+    const s = rollup.toUpperCase()
+    if (s === 'SUCCESS') ciStatus = 'pass'
+    else if (s === 'FAILURE' || s === 'ERROR') ciStatus = 'fail'
+    else if (s) ciStatus = 'pending'
+  }
+
+  // Count unresolved review threads
+  let unresolvedThreads
+  if (Array.isArray(pr.reviewThreads)) {
+    const count = pr.reviewThreads.filter(t => t.isResolved === false).length
+    if (count > 0) unresolvedThreads = count
+  }
+
+  const response = {
+    prNumber: pr.number,
+    prState:  pr.state,
+    ciStatus,
+  }
+  if (unresolvedThreads !== undefined) response.unresolvedThreads = unresolvedThreads
+
+  return response
+}
+
+/**
  * Get a single remote branch (returns null if not found).
  * @param repo
  * @param branch

--- a/src/ipc.js
+++ b/src/ipc.js
@@ -19,17 +19,24 @@
  *   state                          → current lazyhub state snapshot
  *   navigate  { view, prNumber, issueNumber }  → navigate the TUI
  *   open-file { file, line }       → open file in editor from IDE side
+ *   pr-for-branch { branch, repo? }
+ *                                  → { prNumber, prState?, ciStatus?, unresolvedThreads? }
+ *                                     or { prNumber: null } if no PR for the branch
  *
- * Events emitted to all clients:
- *   cursor-changed  { view, prNumber, file, line }
- *   view-changed    { view }
- *   pr-merged       { prNumber }
+ * Events emitted to all clients (via emitIPC):
+ *   cursor-changed    { view, prNumber, file, line }
+ *   view-changed      { view }
+ *   pr-merged         { prNumber }
+ *   pr-state-changed  { branch, prNumber, ciStatus, unresolvedThreads }
+ *     — broadcast helper provided; triggers (CI refresh, merge) ship in later phases.
+ *       Call emitIPC('pr-state-changed', payload) from any refresh path.
  */
 
 import { createServer } from 'net'
 import { join } from 'path'
 import { homedir } from 'os'
 import { writeFileSync, unlinkSync, existsSync } from 'fs'
+import { getPRStateForBranch as _defaultGetPRStateForBranch } from './executor.js'
 
 const SOCKET_POINTER = join(homedir(), '.lazyhub-socket')
 
@@ -37,6 +44,7 @@ let _server = null
 let _clients = new Set()
 let _stateGetter = () => ({})
 let _navigateHandler = null
+let _prForBranchHandler = _defaultGetPRStateForBranch
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -87,6 +95,20 @@ function handleMessage(socket, raw) {
       break
     }
 
+    case 'pr-for-branch': {
+      // nvim statusline / smart :LazyHubPR — look up PR for a branch
+      const branch = msg.branch
+      if (!branch) {
+        sendResponse(socket, id, { prNumber: null })
+        break
+      }
+      // Async handler — respond when the executor call resolves
+      ;(_prForBranchHandler(branch, msg.repo || null))
+        .then(result => sendResponse(socket, id, result))
+        .catch(() => sendResponse(socket, id, { prNumber: null }))
+      break
+    }
+
     default:
       sendResponse(socket, id, { error: `unknown type: ${type}` })
   }
@@ -98,15 +120,18 @@ function handleMessage(socket, raw) {
  * Start the IPC server.
  *
  * @param {object} opts
- * @param {Function} opts.getState      - returns current lazyhub state object
- * @param {Function} opts.onNavigate    - called when IDE sends a navigate request
+ * @param {Function} opts.getState         - returns current lazyhub state object
+ * @param {Function} opts.onNavigate       - called when IDE sends a navigate request
+ * @param {Function} [opts.onPRForBranch]  - async (branch, repo) => { prNumber, ... }
+ *                                           defaults to executor.getPRStateForBranch
  * @returns {string} socket path
  */
-export function startIPC({ getState, onNavigate } = {}) {
+export function startIPC({ getState, onNavigate, onPRForBranch } = {}) {
   if (_server) return socketPath()
 
-  if (getState)   _stateGetter     = getState
-  if (onNavigate) _navigateHandler = onNavigate
+  if (getState)        _stateGetter        = getState
+  if (onNavigate)      _navigateHandler    = onNavigate
+  if (onPRForBranch)   _prForBranchHandler = onPRForBranch
 
   const path = socketPath()
 


### PR DESCRIPTION
## Summary

- Adds the "ambient presence" layer of the nvim integration: a status-line component shows the current branch's PR state (PR #, CI, unread threads) without opening the float.
- `:LazyHubPR` becomes smart — if a PR exists for the current branch, it jumps directly into the PR's diff via IPC; otherwise falls back to the PR list.
- Ships a LazyExtras module so LazyVim users get one-keystroke install with `<leader>gh*` keymaps under a which-key group.
- Full spec at [`NVIM_INTEGRATION_SPEC.md`](./NVIM_INTEGRATION_SPEC.md).

## What's new

| Surface | Behavior |
|---|---|
| Status line | ` PR #123  ✓ CI  💬 2` on lualine/heirline; updates every 30s + on `BufEnter` (5s debounce) + on IPC `pr-state-changed` events |
| `:LazyHubPR` | IPC `pr-for-branch` → if PR exists, navigate float to diff; if lazyhub not running, spawn it with `GHUI_PR=N` |
| `:LazyHub*` (existing) | Unchanged — backwards compatible |
| LazyExtras | `<leader>gh{o,p,b,d,s}` keymaps registered with which-key |

## IPC protocol additions

New request type:
\`\`\`
pr-for-branch { branch, repo? }
  → { prNumber, prState?, ciStatus?: 'pass'|'fail'|'pending'|null, unresolvedThreads? }
  → { prNumber: null } if no PR for the branch
\`\`\`

New event broadcast helper:
\`\`\`
pr-state-changed { branch, prNumber, ciStatus, unresolvedThreads }
\`\`\`
(Triggers — CI refresh, PR merge — ship in a later phase. Event channel ready now.)

## Architecture

Refactored \`integrations/nvim/lua/lazyhub/\` per spec §6 layout:
- \`ipc.lua\` extracted from \`init.lua\` — adds exponential-backoff reconnect (1s → 30s cap)
- \`float.lua\` extracted from \`init.lua\` — unchanged behavior
- \`statusline.lua\` new — lualine + heirline component with libuv-based polling
- \`init.lua\` keeps \`setup()\`, config merging, command registration

Invariants respected:
- All \`gh\` calls go through \`src/executor.js\` (invariant 1)
- Every feature degrades when lazyhub isn't running (invariant 2) — fallback to \`vim.fn.jobstart('gh', ...)\`
- No blocking calls in main loop (invariant 3) — libuv timers, jobstart for slow ops
- No new npm or lua dependencies

## Test plan

- [x] \`npm run lint\` passes on new JS (13 pre-existing errors in unrelated files)
- [x] \`npm test\` — 231 pass, 2 pre-existing GH_HOST failures unrelated
- [x] \`nvim --headless\` setup + statusline.setup() exits 0
- [ ] Manual: lualine renders \` PR #N\` on a branch with an open PR
- [ ] Manual: status-line goes blank on a branch with no PR
- [ ] Manual: \`:LazyHubPR\` jumps to diff when lazyhub is running
- [ ] Manual: \`:LazyHubPR\` spawns lazyhub when not running
- [ ] Manual: LazyVim user installs via copied LazyExtras file → which-key shows \`<leader>gh\` group

## Known limitations

- **\`GHUI_PR\` env not yet honored by lazyhub bootstrap.** The Lua side correctly spawns \`GHUI_PR=N lazyhub\` but the TUI currently ignores it, so the spawn path opens lazyhub at the PR list instead of pre-navigating to the diff. This is graceful degradation (invariant 2); a small follow-up in \`bin/lazyhub.js\` + \`app.jsx\` initial routing wires it through. Tracked as TODO.
- **Server-push events polling-only.** The Lua client polls every 30s rather than holding a long-lived socket connection for \`pr-state-changed\` events. Long-lived subscription ships in Phase 2.

## Not included (separate phases per spec)

- Phase 2: inline review comments (virtual text, reply, resolve)
- Phase 3: pickers (snacks/telescope/fzf-lua) for PRs/issues/checks/reviewers/notifications
- Phase 4: AstroNvim astrocommunity + NvChad packaging
- Phase 5: snacks.terminal adoption, \`:checkhealth lazyhub\`, IPC reconnect tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)