### PR TITLE
fix(ghes): self-hosted PRs broken — hardcoded github.com URL + wrong tests

### DIFF
--- a/src/executor.js
+++ b/src/executor.js
@@ -38,8 +38,10 @@ export class GhError extends Error {
  * @param args
  */
 export async function run(args) {
-  // GH_HOST is inherited by the child process from process.env — no need to
-  // also pass --hostname as a flag (which some gh versions don't accept globally).
+  // GH_HOST is inherited by the child process from process.env. gh CLI honors
+  // it for `--repo OWNER/REPO`-style invocations. We deliberately do NOT pass
+  // --hostname here: it's a per-subcommand flag (valid on `gh api`, `gh auth *`,
+  // `gh repo *`) and is rejected globally by `gh pr list`, `gh issue list`, etc.
   let result
   try {
     result = await execa('gh', args, { reject: false })

--- a/src/executor.test.js
+++ b/src/executor.test.js
@@ -544,13 +544,15 @@ describe('createPR()', () => {
 // ─── GHE / GH_HOST support ───────────────────────────────────────────────────
 
 describe('GH_HOST support', () => {
-  it('passes --hostname flag when GH_HOST is set', async () => {
+  // gh CLI honors GH_HOST via env inheritance for `--repo OWNER/REPO` calls.
+  // We deliberately do NOT pass --hostname: it's invalid on `gh pr list`,
+  // `gh issue list`, etc. (valid only on `gh api`, `gh auth *`, `gh repo *`).
+  it('does not pass --hostname when GH_HOST is set (relies on env inheritance)', async () => {
     process.env.GH_HOST = 'github.example.com'
     mockSuccess([])
     await listPRs('owner/repo')
     const [_cmd, args] = execa.mock.calls[0]
-    expect(args).toContain('--hostname')
-    expect(args).toContain('github.example.com')
+    expect(args).not.toContain('--hostname')
     delete process.env.GH_HOST
   })
 

--- a/src/features/prs/diff.jsx
+++ b/src/features/prs/diff.jsx
@@ -719,7 +719,12 @@ export function PRDiff({ prNumber, repo, onBack, onViewComments }) {
       if (input === 'o') {
         import('execa').then(({ execa }) => {
           const cmd = process.platform === 'darwin' ? 'open' : 'xdg-open'
-          execa(cmd, [`https://github.com/${repo}/pull/${prNumber}/files`]).catch(() => {})
+          // prMeta.url comes from the GitHub API and already reflects the
+          // correct host (github.com or a GHES instance). Fall back to a
+          // GH_HOST-aware constructed URL if prMeta hasn't loaded yet.
+          const baseUrl = prMeta?.url
+            || `https://${process.env.GH_HOST || 'github.com'}/${repo}/pull/${prNumber}`
+          execa(cmd, [`${baseUrl}/files`]).catch(() => {})
         })
         return
       }

--- a/src/flows.test.js
+++ b/src/flows.test.js
@@ -861,12 +861,14 @@ describe('Collaborator flow', () => {
 // ─── GH HOST FLOWS ───────────────────────────────────────────────────────────
 
 describe('GH_HOST env var support', () => {
-  it('prepends --hostname when GH_HOST is set', async () => {
+  // gh CLI honors GH_HOST via env inheritance for `--repo OWNER/REPO` calls.
+  // --hostname is invalid on `gh pr list` / `gh issue list` (valid only on
+  // `gh api`, `gh auth *`, `gh repo *`).
+  it('does not prepend --hostname when GH_HOST is set (env inheritance)', async () => {
     process.env.GH_HOST = 'github.example.com'
     ok([])
     await listPRs('owner/repo')
-    expect(args()).toContain('--hostname')
-    expect(args()).toContain('github.example.com')
+    expect(args()).not.toContain('--hostname')
     delete process.env.GH_HOST
   })
 


### PR DESCRIPTION
## What was broken

When the user reported "self-hosted PRs not working," there were two real bugs hiding behind the two "pre-existing" GH_HOST test failures we've been tolerating since commit \`f6c8acc\` (the original enterprise-support feature).

### Bug 1 — Hardcoded \`github.com\` in the large-diff browser-open path

\`src/features/prs/diff.jsx:722\` constructed the URL manually:

\`\`\`js
execa(cmd, [\`https://github.com/\${repo}/pull/\${prNumber}/files\`]).catch(() => {})
\`\`\`

For a GHES user pressing \`o\` on the "diff is too large" warning, this opens \`https://github.com/<their-private-repo>/pull/N/files\` — wrong host, 404 or worse.

**Every other "open in browser" action in the codebase already uses \`pr.url\` / \`issue.url\` / \`check.url\` from the API response** (which already reflects the correct host: \`github.com\` or \`ghe.example.com\`). Only this one path constructed the URL manually.

**Fix:** Prefer \`prMeta?.url\` (from the GitHub API) with a \`GH_HOST\`-aware fallback when \`prMeta\` hasn't loaded yet.

### Bug 2 — Wrong tests for GHES support

\`src/executor.test.js\` and \`src/flows.test.js\` had been failing for months, asserting that \`gh pr list\` should receive a \`--hostname\` flag when \`GH_HOST\` was set:

\`\`\`js
expect(args).toContain('--hostname')
\`\`\`

But **\`--hostname\` isn't a global gh flag.** It's per-subcommand and valid only on \`gh api\`, \`gh auth *\`, \`gh repo *\`. \`gh pr list\` and \`gh issue list\` reject it. They rely on \`GH_HOST\` env-var inheritance, which is exactly what \`executor.js\` already does (line 41–44).

The tests were aspirational and have been red since the GHES feature commit. They've been masking the fact that the GHES path is actually correct *for gh CLI calls* — the broken piece is the URL hardcode in Bug 1.

**Fix:** Tests updated to assert the correct behavior (no \`--hostname\` on \`gh pr list\`; env inheritance does the work).

## Also clarified

The comment in \`executor.js#run()\` said "some gh versions don't accept --hostname globally" — vague. Replaced with the real reason: \`--hostname\` is a per-subcommand flag, not a global one, and is rejected by \`gh pr list\` / \`gh issue list\`.

## Audit performed

Grepped all \`src/**/*.{js,jsx}\` for hardcoded \`github.com\` URLs in production code. **Only \`diff.jsx:722\` was wrong.** Every other URL-open path uses fields returned by the API (\`pr.url\`, \`issue.url\`, \`check.url\`, etc.) and works correctly for GHES because GitHub's API returns the correct host.

## Test plan

- [x] \`npm test\` — **233 / 234 passing** (1 skipped; zero failures — the previous 2 GH_HOST failures are now green)
- [ ] Manual: in a GHES repo, open a PR with a large diff, press \`o\` → opens \`https://<your-ghes-host>/owner/repo/pull/N/files\`
- [ ] Manual: in a github.com repo, same flow opens \`https://github.com/owner/repo/pull/N/files\`
- [ ] Manual: \`GH_HOST=github.example.com gh pr list --repo owner/repo\` (run by hand) — confirms gh honors env inheritance without \`--hostname\`

## Diff size

4 files, +20 / -9 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)