### PR TITLE
fix: pin react to ^18 — unbreak ink 4 reconciler

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,15 @@ updates:
     open-pull-requests-limit: 5
     versioning-strategy: increase
     # Security alerts open separately and are auto-opened by GitHub regardless.
+    ignore:
+      # React majors must be coordinated with an Ink major bump.
+      # Ink 4 → 6 is its own upgrade project. Until then, stay on React 18.
+      - dependency-name: react
+        update-types: [version-update:semver-major]
+      - dependency-name: '@types/react'
+        update-types: [version-update:semver-major]
+      - dependency-name: ink
+        update-types: [version-update:semver-major]
 
   - package-ecosystem: github-actions
     directory: /

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "execa": "^8.0.1",
         "highlight.js": "^11.9.0",
         "ink": "^4.4.1",
-        "react": "^19.2.6",
+        "react": "^18.3.1",
         "timeago.js": "^4.0.2"
       },
       "bin": {
@@ -4463,10 +4463,13 @@
       "license": "MIT"
     },
     "node_modules/react": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
-      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
       "engines": {
         "node": ">=0.10.0"
       }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "execa": "^8.0.1",
     "highlight.js": "^11.9.0",
     "ink": "^4.4.1",
-    "react": "^19.2.6",
+    "react": "^18.3.1",
     "timeago.js": "^4.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
## Why

Dependabot PR #107 bumped \`react@18.3.1\` → \`react@19.2.6\` and was auto-merged. This broke \`ink@4.4.1\`'s bundled \`react-reconciler\`:

\`\`\`
TypeError: Cannot read properties of undefined (reading 'ReactCurrentOwner')
 ❯ node_modules/ink/node_modules/react-reconciler/cjs/react-reconciler.development.js:491:46
 ❯ node_modules/ink/src/reconciler.ts:96:15
\`\`\`

\`ReactCurrentOwner\` is an internal React API that no longer exists in React 19. Ink 4 still depends on it; Ink 6 (which supports React 19) is a separate upgrade with API changes.

After this fix: **339 tests pass** (was 316 broken / 1 file fully failing on \`main\`).

## What changed

- \`package.json\`: \`react\` pinned to \`^18.3.1\`
- \`package-lock.json\`: regenerated
- \`.github/dependabot.yml\`: ignore \`semver:major\` for \`react\`, \`@types/react\`, and \`ink\`. They must be coordinated (Ink 4 = React 18; Ink 6 = React 19). Dependabot doesn't understand this constraint, so we lock it out until we run the upgrade deliberately as its own project.

## Open follow-up

Ink 4 → 6 upgrade is its own coordinated project. Worth doing for React 19 + Ink's newer features (improved hooks, better scrolling primitives), but **not** as part of a bug-fix PR. I'd schedule it after Phase C step 1-4 land so we have a theme system in place to validate against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)