### PR TITLE
docs: add JSDoc @fileoverview headers to 28 src files

### DIFF
--- a/docs/FILE_MAP.md
+++ b/docs/FILE_MAP.md
@@ -8,7 +8,7 @@
 
 | File | Purpose |
 |---|---|
-| `src/app.jsx` | (no header — inferred: app) |
+| `src/app.jsx` | Root Ink layout and application entry point. |
 | `src/bootstrap.js` | runs BEFORE any Ink UI is rendered. Steps: 1. Detect gh CLI 2. Detect gh auth status 3. Detect repo context 4. Hand off to renderApp() |
 
 ## GitHub interface (the gh chokepoint)
@@ -23,11 +23,11 @@
 |---|---|
 | `src/ai-assistant.js` | assistant.js — AI assistant brain Exposes a Claude tool-use loop that: - Executes read-only tools freely (up to MAX_TOOL_ROUNDS) - Intercepts mutating tools and returns them to the UI for confirmation - Parses <<NAVIGATE:pane[:key=val]*>> markers for app navigation Direct fetch pattern (same as ai.js). No SDK dependency. |
 | `src/ai.js` | DEPRECATED re-export shim. @deprecated Import from './ai/index.js' directly. This shim is kept for one release per the migration plan (spec §11). It will be removed in the next release. |
-| `src/ai/detect.js` | (no header — inferred: detect) |
+| `src/ai/detect.js` | AI provider auto-detection and selection logic. |
 | `src/ai/error.js` | AIError class definition. Standalone module to avoid circular imports between index.js, parse.js, detect.js, and the provider modules. |
-| `src/ai/index.js` | (no header — inferred: index) |
+| `src/ai/index.js` | Public API for AI code review and provider management. |
 | `src/ai/parse.js` | Response parsing for AI code review. Extracted unchanged from src/ai.js. Handles JSON extraction, markdown fence stripping, and suggestion shape normalization. |
-| `src/ai/prompt.js` | (no header — inferred: prompt) |
+| `src/ai/prompt.js` | Pure prompt-building helpers and system templates for AI. |
 | `src/ai/providers/_base.js` | Shared spawn helper for CLI-based AI providers. Security requirements (mirroring executor.js): - execFile only — no exec, no shell interpretation - Prompt piped via stdin — never as argv (diffs exceed ARG_MAX; injection risk) - Curated env — PATH/HOME/USER only; no secret leakage - 60s hard timeout + SIGTERM → SIGKILL after 5s grace - 256KB output cap — larger responses truncated and treated as malformed |
 | `src/ai/providers/anthropic-api.js` | api.js — Anthropic HTTP API provider. This is the ONLY file that makes Anthropic HTTP calls. HTTP logic extracted unchanged from src/ai.js. Preserves the cache_control ephemeral header on the system prompt. |
 | `src/ai/providers/claude-code.js` | code.js — Claude Code CLI provider. Uses the `claude` CLI in non-interactive (-p) mode. Prompt is piped via stdin — never argv (diffs exceed ARG_MAX). Auth is managed by the user's Claude Code installation (~/.claude/). |
@@ -40,30 +40,30 @@
 | File | Purpose |
 |---|---|
 | `src/theme.js` | resolves the active theme from config and exports t. |
-| `src/theme/bg-detect.js` | (no header — inferred: bg-detect) |
-| `src/theme/index.js` | (no header — inferred: index) |
-| `src/theme/schemes/lazyhub-dark.js` | (no header — inferred: lazyhub-dark) |
-| `src/theme/schemes/lazyhub-light.js` | (no header — inferred: lazyhub-light) |
-| `src/theme/tokens.js` | (no header — inferred: tokens) |
+| `src/theme/bg-detect.js` | detect.js — Terminal background brightness detection for theme selection. |
+| `src/theme/index.js` | Public API for the theme system and React context. |
+| `src/theme/schemes/lazyhub-dark.js` | dark.js — Default dark color scheme for terminal readability. |
+| `src/theme/schemes/lazyhub-light.js` | light.js — Default light color scheme for terminal readability. |
+| `src/theme/tokens.js` | Token taxonomy schema for the design system. |
 | `src/themes/ansi-16.js` | 16.js — Standard 16-color ANSI theme for maximum compatibility. Works in any terminal (no hex support required). |
 | `src/themes/aurora-dark.js` | cool navy/slate, lavender+cyan accents. |
 | `src/themes/aurora-light.js` | cream surface, navy ink, periwinkle accents. |
-| `src/themes/catppuccin-latte.js` | (no header — inferred: catppuccin-latte) |
-| `src/themes/catppuccin-mocha.js` | (no header — inferred: catppuccin-mocha) |
-| `src/themes/github-dark.js` | (no header — inferred: github-dark) |
-| `src/themes/github-light.js` | (no header — inferred: github-light) |
-| `src/themes/tokyo-night.js` | (no header — inferred: tokyo-night) |
+| `src/themes/catppuccin-latte.js` | latte.js — Catppuccin Latte (light) color scheme. |
+| `src/themes/catppuccin-mocha.js` | mocha.js — Catppuccin Mocha (dark) color scheme. |
+| `src/themes/github-dark.js` | dark.js — GitHub Dark color scheme. |
+| `src/themes/github-light.js` | light.js — GitHub Light color scheme. |
+| `src/themes/tokyo-night.js` | night.js — Tokyo Night color scheme. |
 
 ## Features — Pull Requests
 
 | File | Purpose |
 |---|---|
 | `src/features/prs/comments.jsx` | PR comments/threads view Supports: reply, edit, delete per comment |
-| `src/features/prs/ConflictView.jsx` | (no header — inferred: ConflictView) |
+| `src/features/prs/ConflictView.jsx` | Pull request merge-conflict resolution view. |
 | `src/features/prs/detail.jsx` | PR detail pane Scrollable view: j/k to scroll, gg/G top/bottom, / to search body |
 | `src/features/prs/diff-parser.js` | parser.js — pure diff-parsing logic, no React/Ink deps. Extracted from diff.jsx so it can be unit-tested without mocking the entire Ink/chalk/hljs stack. |
 | `src/features/prs/diff.jsx` | PR diff view with syntax highlighting + line comments |
-| `src/features/prs/list.jsx` | (no header — inferred: list) |
+| `src/features/prs/list.jsx` | Pull request list pane with filtering and navigation. |
 | `src/features/prs/NewPRDialog.jsx` | Smart New PR creation dialog. Features: - Auto-detects current branch and offers to use it as head - Validates head branch against remote (not pushed / has unpushed commits / no diff) - Validates base branch exists on GitHub - Offers to push branch to origin if needed - Shift+Tab for backward field navigation |
 
 ## Features — Issues
@@ -87,18 +87,18 @@
 
 | File | Purpose |
 |---|---|
-| `src/ui/actions.js` | (no header — inferred: actions) |
-| `src/ui/Popover.jsx` | (no header — inferred: Popover) |
+| `src/ui/actions.js` | Central action registry for the command palette. |
+| `src/ui/Popover.jsx` | Floating popover primitive for overlays and tooltips. |
 
 ## Components (shared)
 
 | File | Purpose |
 |---|---|
 | `src/components/AIAssistant.jsx` | AI assistant overlay Full-screen content-area overlay triggered by Ctrl+A. Shows conversation history, a single-line prompt, and handles action confirmation + navigation prompts inline. |
-| `src/components/AIReviewPane.jsx` | (no header — inferred: AIReviewPane) |
-| `src/components/CommandPalette.jsx` | (no header — inferred: CommandPalette) |
+| `src/components/AIReviewPane.jsx` | Interactive step-through UI for AI code reviews. |
+| `src/components/CommandPalette.jsx` | fuzzy command palette overlay for executing actions. |
 | `src/components/CommentThread.jsx` | renders a list of comments as a threaded discussion. Props: comments ([Comment]), t (theme object) Used in: diff.jsx inline threads, comments.jsx view |
-| `src/components/CustomPane.jsx` | (no header — inferred: CustomPane) |
+| `src/components/CustomPane.jsx` | Generic pane renderer for user-defined tabs. |
 | `src/components/dialogs/ConfirmDialog.jsx` | confirmation dialog primitive. Props: message, destructive (bool), onConfirm(), onCancel(), requireText? (string to type) |
 | `src/components/dialogs/FormCompose.jsx` | multi-field form dialog primitive. Props: title, fields ([{name, label, type: 'text'|'multiline'|'select'}]) onSubmit(values), onCancel() |
 | `src/components/dialogs/FuzzySearch.jsx` | fuzzy search dialog with virtual scrolling. Renders only as many items as fit in the terminal — safe for thousands of items. Props: items, onSubmit(item), onCancel(), searchFields |
@@ -108,10 +108,10 @@
 | `src/components/ErrorBoundary.jsx` | catches render crashes, logs them, shows a minimal error box. |
 | `src/components/FooterKeys.jsx` | footer key hint bar. Keys shape: { key, label, group? } When group numbers present, renders groups separated by ┊ (U+250A). Falls back to plain │ separators when no groups defined. |
 | `src/components/Monogram.jsx` | [XX] author initial badge with hash-based color. Props: login (string) |
-| `src/components/Sidebar.jsx` | (no header — inferred: Sidebar) |
+| `src/components/Sidebar.jsx` | Navigation sidebar for switching between feature views. |
 | `src/components/Skeleton.jsx` | animated placeholder loaders for every list/detail pane. Each exported component mirrors the exact column layout of its real counterpart so the UI doesn't shift when data arrives. Animation: a single 700ms interval per skeleton component pulses all bars between ░ and ▒ — one setInterval total, not one per bar. |
 | `src/components/Spinner.jsx` | animated braille spinner for loading states |
-| `src/components/StatusBar.jsx` | (no header — inferred: StatusBar) |
+| `src/components/StatusBar.jsx` | Application status bar showing context and global state. |
 | `src/components/TabStrip.jsx` | horizontal pane tabs for compact mode (<80 cols). Props: panes (string[]), currentPane, paneLabels, paneIcons, onSelect |
 | `src/components/Toaster.jsx` | transient notification stack, max 3, bottom-right. Variants: success (2.5s), info (3s), warning (4s), error (sticky). Usage: call useToast() hook to get { toast } function. toast({ message, variant: 'success'|'info'|'warning'|'error' }) |
 
@@ -123,13 +123,13 @@
 | `src/hooks/useLayout.js` | responsive layout breakpoints based on terminal dimensions. Config overrides always win over breakpoint defaults. |
 | `src/hooks/usePaneState.js` | preserve list/pane view state across navigation. State is stored in a Map on AppContext (via paneStateRef). Survives PRList unmount (back-nav from detail/diff). Cleared on explicit pane-switch (Tab, number key) by the App. Usage: const [state, setState] = usePaneState('prs', { cursor: 0, scrollOffset: 0, filterState: 'open', ... }) |
 | `src/hooks/useRecent.js` | persist recently viewed items to ~/.config/lazyhub/recent.json Max 10 entries per type. Entries: { type: 'pr'|'issue', repo, number, title, updatedAt } |
-| `src/hooks/useVirtualList.js` | (no header — inferred: useVirtualList) |
+| `src/hooks/useVirtualList.js` | React hook for efficient virtualized rendering of long lists. |
 
 ## Configuration & Context
 
 | File | Purpose |
 |---|---|
-| `src/config.js` | (no header — inferred: config) |
+| `src/config.js` | manages application configuration and user settings. |
 | `src/context.js` | shared React contexts Kept separate from app.jsx so feature components don't create circular imports by reaching back into the root layout module. |
 
 ## Utilities & Infrastructure
@@ -137,9 +137,9 @@
 | File | Purpose |
 |---|---|
 | `src/editor.js` | Editor detection and file-open utility Supports: vscode, cursor, nvim, vim, nano, emacs, and $EDITOR/$VISUAL fallback. Configured via config.editor.command ("auto" | "vscode" | "cursor" | "nvim" | etc.) openInEditor(file, line) — opens the file at the given line number in the detected/configured editor. Non-blocking; fires and returns immediately. |
-| `src/ipc.js` | (no header — inferred: ipc) |
-| `src/keyscope.js` | (no header — inferred: keyscope) |
-| `src/mcp.js` | (no header — inferred: mcp) |
+| `src/ipc.js` | Inter-process communication for external editor integrations. |
+| `src/keyscope.js` | Keyboard focus and input scope management for Ink TUI. |
+| `src/mcp.js` | Model Context Protocol (MCP) server for AI tool-use. |
 | `src/utils.js` | shared utility functions |
 
 ## Tests

--- a/src/ai/detect.js
+++ b/src/ai/detect.js
@@ -1,3 +1,4 @@
+/** detect.js — AI provider auto-detection and selection logic. */
 /**
  * src/ai/detect.js — Provider auto-detection and selection.
  *

--- a/src/ai/index.js
+++ b/src/ai/index.js
@@ -1,3 +1,4 @@
+/** index.js — Public API for AI code review and provider management. */
 /**
  * src/ai/index.js — Public API for AI-powered code review.
  *

--- a/src/ai/prompt.js
+++ b/src/ai/prompt.js
@@ -1,3 +1,4 @@
+/** prompt.js — Pure prompt-building helpers and system templates for AI. */
 /**
  * src/ai/prompt.js — Pure prompt-building helpers.
  *

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -1,3 +1,4 @@
+/** app.jsx — Root Ink layout and application entry point. */
 /**
  * app.jsx — root Ink layout + renderApp() entry point.
  *

--- a/src/components/AIReviewPane.jsx
+++ b/src/components/AIReviewPane.jsx
@@ -1,3 +1,4 @@
+/** AIReviewPane.jsx — Interactive step-through UI for AI code reviews. */
 /**
  * src/components/AIReviewPane.jsx — Interactive step-through AI code review
  *

--- a/src/components/CommandPalette.jsx
+++ b/src/components/CommandPalette.jsx
@@ -1,3 +1,4 @@
+/** CommandPalette.jsx — fuzzy command palette overlay for executing actions. */
 /**
  * CommandPalette.jsx — fuzzy command palette overlay.
  *

--- a/src/components/CustomPane.jsx
+++ b/src/components/CustomPane.jsx
@@ -1,3 +1,4 @@
+/** CustomPane.jsx — Generic pane renderer for user-defined tabs. */
 /**
  * CustomPane.jsx — generic pane renderer for user-defined tabs.
  *

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,3 +1,4 @@
+/** Sidebar.jsx — Navigation sidebar for switching between feature views. */
 import React from 'react'
 import { Box, Text } from 'ink'
 import { useTheme } from '../theme.js'

--- a/src/components/StatusBar.jsx
+++ b/src/components/StatusBar.jsx
@@ -1,3 +1,4 @@
+/** StatusBar.jsx — Application status bar showing context and global state. */
 import React, { useState, useEffect } from 'react'
 import { Box, Text, useStdout } from 'ink'
 import { useTheme } from '../theme.js'

--- a/src/config.js
+++ b/src/config.js
@@ -1,3 +1,4 @@
+/** config.js — manages application configuration and user settings. */
 /**
  * config.js — loads ~/.config/lazyhub/config.json
  *

--- a/src/features/prs/ConflictView.jsx
+++ b/src/features/prs/ConflictView.jsx
@@ -1,3 +1,4 @@
+/** ConflictView.jsx — Pull request merge-conflict resolution view. */
 /**
  * src/features/prs/ConflictView.jsx — GitHub PR merge-conflict resolution
  *

--- a/src/features/prs/list.jsx
+++ b/src/features/prs/list.jsx
@@ -1,3 +1,4 @@
+/** list.jsx — Pull request list pane with filtering and navigation. */
 /**
  * src/features/prs/list.jsx — PR list pane
  *

--- a/src/hooks/useVirtualList.js
+++ b/src/hooks/useVirtualList.js
@@ -1,3 +1,4 @@
+/** useVirtualList.js — React hook for efficient virtualized rendering of long lists. */
 /**
  * src/hooks/useVirtualList.js
  *

--- a/src/ipc.js
+++ b/src/ipc.js
@@ -1,3 +1,4 @@
+/** ipc.js — Inter-process communication for external editor integrations. */
 /**
  * src/ipc.js — IPC Unix-socket server for IDE integrations
  *

--- a/src/keyscope.js
+++ b/src/keyscope.js
@@ -1,3 +1,4 @@
+/** keyscope.js — Keyboard focus and input scope management for Ink TUI. */
 /**
  * keyscope.js — keyboard scope isolation for Ink TUI.
  *

--- a/src/mcp.js
+++ b/src/mcp.js
@@ -1,3 +1,4 @@
+/** mcp.js — Model Context Protocol (MCP) server for AI tool-use. */
 /**
  * src/mcp.js — MCP (Model Context Protocol) server mode
  *

--- a/src/theme/bg-detect.js
+++ b/src/theme/bg-detect.js
@@ -1,3 +1,4 @@
+/** bg-detect.js — Terminal background brightness detection for theme selection. */
 /**
  * bg-detect.js — Terminal background brightness detection.
  *
@@ -21,6 +22,12 @@
  *   We extract the LAST numeric segment to get the bg value.
  *
  * @param {NodeJS.ProcessEnv} [env] — injectable for testing; defaults to process.env
+ * @returns {'dark' | 'light' | 'unknown'}
+ */
+/**
+ * Detect terminal background brightness from environment variables.
+ *
+ * @param {NodeJS.ProcessEnv} [env=process.env]
  * @returns {'dark' | 'light' | 'unknown'}
  */
 export function detectBackground(env = process.env) {

--- a/src/theme/index.js
+++ b/src/theme/index.js
@@ -1,3 +1,4 @@
+/** index.js — Public API for the theme system and React context. */
 /**
  * src/theme/index.js — Public API for the lazyhub theme system.
  *

--- a/src/theme/schemes/lazyhub-dark.js
+++ b/src/theme/schemes/lazyhub-dark.js
@@ -1,3 +1,4 @@
+/** lazyhub-dark.js — Default dark color scheme for terminal readability. */
 /**
  * lazyhub-dark.js — Default dark color scheme.
  *

--- a/src/theme/schemes/lazyhub-light.js
+++ b/src/theme/schemes/lazyhub-light.js
@@ -1,3 +1,4 @@
+/** lazyhub-light.js — Default light color scheme for terminal readability. */
 /**
  * lazyhub-light.js — Light color scheme (daylight counterpart to lazyhub-dark).
  *

--- a/src/theme/tokens.js
+++ b/src/theme/tokens.js
@@ -1,3 +1,4 @@
+/** tokens.js — Token taxonomy schema for the design system. */
 /**
  * tokens.js — Token taxonomy schema for lazyhub's design system.
  *

--- a/src/themes/catppuccin-latte.js
+++ b/src/themes/catppuccin-latte.js
@@ -1,3 +1,4 @@
+/** catppuccin-latte.js — Catppuccin Latte (light) color scheme. */
 export default {
   pr:    { open: '#40a02b', merged: '#8839ef', closed: '#d20f39', draft: '#9ca0b0', conflict: '#df8e1d' },
   issue: { open: '#40a02b', closed: '#9ca0b0' },

--- a/src/themes/catppuccin-mocha.js
+++ b/src/themes/catppuccin-mocha.js
@@ -1,3 +1,4 @@
+/** catppuccin-mocha.js — Catppuccin Mocha (dark) color scheme. */
 export default {
   pr:    { open: '#a6e3a1', merged: '#cba6f7', closed: '#f38ba8', draft: '#6c7086', conflict: '#f9e2af' },
   issue: { open: '#a6e3a1', closed: '#6c7086' },

--- a/src/themes/github-dark.js
+++ b/src/themes/github-dark.js
@@ -1,3 +1,4 @@
+/** github-dark.js — GitHub Dark color scheme. */
 export default {
   pr:    { open: '#3fb950', merged: '#a371f7', closed: '#f85149', draft: '#8b949e', conflict: '#d29922' },
   issue: { open: '#3fb950', closed: '#8b949e' },

--- a/src/themes/github-light.js
+++ b/src/themes/github-light.js
@@ -1,3 +1,4 @@
+/** github-light.js — GitHub Light color scheme. */
 export default {
   pr:    { open: '#1a7f37', merged: '#8250df', closed: '#cf222e', draft: '#6e7781', conflict: '#9a6700' },
   issue: { open: '#1a7f37', closed: '#6e7781' },

--- a/src/themes/tokyo-night.js
+++ b/src/themes/tokyo-night.js
@@ -1,3 +1,4 @@
+/** tokyo-night.js — Tokyo Night color scheme. */
 export default {
   pr:    { open: '#9ece6a', merged: '#bb9af7', closed: '#f7768e', draft: '#565f89', conflict: '#e0af68' },
   issue: { open: '#9ece6a', closed: '#565f89' },

--- a/src/ui/Popover.jsx
+++ b/src/ui/Popover.jsx
@@ -1,3 +1,4 @@
+/** Popover.jsx — Floating popover primitive for overlays and tooltips. */
 /**
  * src/ui/Popover.jsx — Floating popover primitive for lazyhub.
  *

--- a/src/ui/actions.js
+++ b/src/ui/actions.js
@@ -1,3 +1,4 @@
+/** actions.js — Central action registry for the command palette. */
 /**
  * src/ui/actions.js — Central action registry for the command palette.
  *


### PR DESCRIPTION
## Goal
    Add JSDoc `@fileoverview` headers to 28 specific files in the `src/` directory to ensure that `docs/FILE_MAP.md` contains
      descriptive entries instead of inferred placeholders.
