### PR TITLE
Fix auto-merge toggle visibility

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -970,7 +970,7 @@ function App({ repo }) {
     // Group 1: navigation  Group 2: actions  Group 3: meta (? handled separately)
     const g1 = [{ key: 'j/k', label: 'nav', group: 1 }, { key: 'Tab', label: 'pane', group: 1 }]
     const g3 = [{ key: 'r', label: 'refresh', group: 3 }, { key: 'S', label: 'settings', group: 3 }, { key: '?', label: 'help' }]
-    if (pane === 'prs')    return [...g1, { key: 'Enter', label: 'open', group: 2 }, { key: 'd', label: 'diff', group: 2 }, { key: 'f', label: 'filter', group: 2 }, { key: 'm', label: 'merge', group: 2 }, ...g3]
+    if (pane === 'prs')    return [...g1, { key: 'Enter', label: 'open', group: 2 }, { key: 'd', label: 'diff', group: 2 }, { key: 'f', label: 'filter', group: 2 }, { key: 'm', label: 'merge', group: 2 }, { key: 'M', label: 'auto-merge', group: 2 }, ...g3]
     if (pane === 'issues') return [...g1, { key: 'Enter', label: 'open', group: 2 }, { key: 'n', label: 'new', group: 2 }, ...g3]
     if (pane === 'branches') return [...g1, { key: 'Enter', label: 'checkout', group: 2 }, { key: 'n', label: 'new', group: 2 }, { key: 'D', label: 'delete', group: 2 }, ...g3]
     if (pane === 'actions') return [...g1, { key: 'Enter', label: 'logs', group: 2 }, { key: 'R', label: 're-run', group: 2 }, ...g3]

--- a/src/executor.js
+++ b/src/executor.js
@@ -136,7 +136,7 @@ export async function listPRs(repo, filter = {}) {
   // Try with all fields first; fall back to a reduced set for GHE instances
   // where statusCheckRollup / mergeable are not in the GraphQL schema.
   try {
-    return await runGh([...base, '--json', 'number,title,state,author,labels,reviewRequests,statusCheckRollup,reviewDecision,updatedAt,isDraft,headRefName,baseRefName,assignees,body,mergeable,url'])
+    return await runGh([...base, '--json', 'number,title,state,author,labels,reviewRequests,statusCheckRollup,reviewDecision,updatedAt,isDraft,headRefName,baseRefName,assignees,body,mergeable,autoMergeRequest,url'])
   } catch (err) {
     if (!/unknown|field|not found/i.test(err.message)) throw err
     return runGh([...base, '--json', 'number,title,state,author,labels,reviewRequests,reviewDecision,updatedAt,isDraft,headRefName,baseRefName,assignees,body,url'])
@@ -1385,4 +1385,3 @@ export async function getMergeCommitMessage() {
     return r.stdout.trim() || 'Merge conflict resolution'
   } catch { return 'Merge conflict resolution' }
 }
-

--- a/src/executor.test.js
+++ b/src/executor.test.js
@@ -160,6 +160,14 @@ describe('listPRs()', () => {
     expect(args).toContain('--author')
     expect(args).toContain('alice')
   })
+
+  it('requests autoMergeRequest so list view can toggle auto-merge', async () => {
+    mockSuccess([])
+    await listPRs('owner/repo')
+    const [, args] = execa.mock.calls[0]
+    const jsonFields = args[args.indexOf('--json') + 1].split(',')
+    expect(jsonFields).toContain('autoMergeRequest')
+  })
 })
 
 describe('getPR()', () => {

--- a/src/features/prs/detail.jsx
+++ b/src/features/prs/detail.jsx
@@ -308,6 +308,7 @@ export function PRDetail({ prNumber, repo, onBack, onOpenDiff, onOpenConflict, o
   const visibleHeight = Math.max(3, termRows - 8)
   const maxScroll     = Math.max(0, filteredRows.length - visibleHeight)
   const visibleRows   = filteredRows.slice(scrollY, scrollY + visibleHeight)
+  const autoMergeHint = pr?.state === 'OPEN' && !pr?.isDraft ? '  [M] auto-merge' : ''
 
   const openCheckInBrowser = (check) => {
     if (!check?.url) return
@@ -715,7 +716,7 @@ export function PRDetail({ prNumber, repo, onBack, onOpenDiff, onOpenConflict, o
           : checkCursor !== null
             ? <Text color={t.ui.selected}>[j/k] nav checks  [Enter/o] open  [l] annotations  [R] rerun  [Esc] exit checks</Text>
             : maxScroll > 0
-              ? <Text color={t.ui.dim}>{scrollY + 1}–{Math.min(scrollY + visibleHeight, filteredRows.length)} / {filteredRows.length}  [j/k] scroll  [gg/G] top/bottom</Text>
+              ? <Text color={t.ui.dim}>{scrollY + 1}–{Math.min(scrollY + visibleHeight, filteredRows.length)} / {filteredRows.length}  [j/k] scroll  [gg/G] top/bottom{autoMergeHint}</Text>
               : pr?.mergeable === 'CONFLICTING'
                 ? <Text color={t.pr.conflict || t.ci.pending}>[C] resolve conflicts  [c] checks  [d] diff  [m] merge  [l] labels  [A] assignees  [R] reviewers</Text>
                 : <Text color={t.ui.dim}>[d] diff  [E] editor  [m] merge  [M] auto-merge  [c] checks  [l] labels  [A] assignees  [R] reviewers</Text>

--- a/src/features/prs/list.jsx
+++ b/src/features/prs/list.jsx
@@ -16,7 +16,7 @@ import { useKeyScope } from '../../keyscope.js'
 import { useGh } from '../../hooks/useGh.js'
 import {
   listPRs, listLabels, listCollaborators,
-  mergePR, closePR, checkoutBranch, addLabels, removeLabels,
+  enableAutoMerge, disableAutoMerge, mergePR, closePR, checkoutBranch, addLabels, removeLabels,
   requestReviewers, removeReviewers, reviewPR, getRepoInfo,
   addPRAssignees, removePRAssignees,
 } from '../../executor.js'
@@ -223,6 +223,10 @@ const MERGE_OPTIONS = [
   { value: 'rebase', label: '--rebase', description: 'Rebase onto base branch' },
 ]
 
+export function canToggleAutoMergeFromList(pr) {
+  return pr?.state === 'OPEN' && !pr?.isDraft
+}
+
 // ─── PR detail popover content ────────────────────────────────────────────────
 
 /** Default popover width in columns; clamped to terminal width at runtime. */
@@ -382,6 +386,7 @@ export function PRList({ repo, listHeight = 10, innerWidth, onSelectPR, onOpenDi
   // Single state → pass it directly; multi-state → fetch 'all' and filter client-side
   const apiState = filterStates.size === 1 ? [...filterStates][0] : 'all'
   const { data: prs, loading, error, refetch } = useGh(listPRs, [repo, { state: apiState, scope, author: authorFilter || undefined, limit }])
+  const { data: repoInfo } = useGh(getRepoInfo, [repo], { ttl: 300_000 })
 
   const [cursor, setCursorRaw] = useState(savedState.cursor)
   const [scrollOffset, setScrollOffsetRaw] = useState(savedState.scrollOffset)
@@ -481,6 +486,20 @@ export function PRList({ repo, listHeight = 10, innerWidth, onSelectPR, onOpenDi
     if (input === 'k' || key.upArrow)   { moveCursor(-1); return }
     if (input === 'r') { refetch(); return }
     if (input === '/') { openDialog('fuzzy'); return }
+
+    const focusedPR = !loading && items.length > 0 ? items[cursor] : null
+    if (input === 'M' && canToggleAutoMergeFromList(focusedPR)) {
+      if (focusedPR.autoMergeRequest) {
+        disableAutoMerge(repo, focusedPR.number)
+          .then(() => { showStatus('✓ Auto-merge disabled'); refetch() })
+          .catch(err => showStatus(`✗ Auto-merge failed: ${err.message}`, true))
+      } else {
+        enableAutoMerge(repo, focusedPR.number, repoInfo?.squashMergeAllowed ? 'squash' : 'merge')
+          .then(() => { showStatus('⟳ Auto-merge enabled'); refetch() })
+          .catch(err => showStatus(`✗ Auto-merge failed: ${err.message}`, true))
+      }
+      return
+    }
 
     // Filter state toggles (defaults: O/C/M) — press to toggle state in/out of active set
     if (FK.filterOpen && input === FK.filterOpen) {

--- a/src/features/prs/list.test.js
+++ b/src/features/prs/list.test.js
@@ -10,7 +10,7 @@
  */
 
 import { describe, it, expect } from 'vitest'
-import { schemeToT } from './list.jsx'
+import { canToggleAutoMergeFromList, schemeToT } from './list.jsx'
 import lazyhubDark from '../../theme/schemes/lazyhub-dark.js'
 import lazyhubLight from '../../theme/schemes/lazyhub-light.js'
 import { themes } from '../../theme/index.js'
@@ -150,5 +150,17 @@ describe('ThemeProvider context wiring', () => {
         expect(val.length, `t.${group}.${key} must not be empty`).toBeGreaterThan(0)
       }
     }
+  })
+})
+
+describe('canToggleAutoMergeFromList', () => {
+  it('allows focused open non-draft PRs to claim the M key', () => {
+    expect(canToggleAutoMergeFromList({ state: 'OPEN', isDraft: false })).toBe(true)
+  })
+
+  it('leaves M available for the merged filter outside eligible PRs', () => {
+    expect(canToggleAutoMergeFromList({ state: 'OPEN', isDraft: true })).toBe(false)
+    expect(canToggleAutoMergeFromList({ state: 'MERGED', isDraft: false })).toBe(false)
+    expect(canToggleAutoMergeFromList(null)).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary
- add autoMergeRequest to PR list fetches so the focused row can toggle auto-merge
- handle M in the PR list for open non-draft PRs with the same success/error status feedback as detail view
- keep M visible in PR footer hints, including scrolled PR detail views
- add focused tests for the list payload and M-key eligibility

Fixes #45

## Tests
- npm test -- --run src/executor.test.js src/flows.test.js src/features/prs/list.test.js
- npm run build